### PR TITLE
feat: implement configurable request timeout for JSON-RPC server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "pelican"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "actix-web",
  "actix-ws",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pelican"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 
 [dependencies]

--- a/src/jsonrpc/server.rs
+++ b/src/jsonrpc/server.rs
@@ -28,7 +28,7 @@ use tokio::sync::oneshot::Receiver;
 use tokio::task::spawn_local;
 use tokio::time::timeout;
 
-const TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
 
 pub struct AppRequest {
     pub request: JsonRpcRequest,
@@ -38,6 +38,7 @@ pub struct AppRequest {
 #[derive(Default)]
 pub struct AppData {
     pub rpc_queue: VecDeque<AppRequest>,
+    pub timeout: Duration,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -51,6 +52,7 @@ struct Health {
 struct ServerConfig {
     host: String,
     port: u16,
+    timeout: Option<u64>,
 }
 
 impl FromLua for ServerConfig {
@@ -66,9 +68,20 @@ pub struct JsonRpcServer {
     app_data: Data<Mutex<AppData>>,
 }
 
+impl AppData {
+    fn new(timeout: Duration) -> Self {
+        AppData {
+            rpc_queue: VecDeque::new(),
+            timeout,
+        }
+    }
+}
+
 impl JsonRpcServer {
     fn new(config: ServerConfig) -> Result<Self, actix_web::Error> {
-        let app_data = Data::new(Mutex::new(AppData::default()));
+        let app_data = Data::new(Mutex::new(AppData::new(get_timeout_duration_from_config(
+            &config,
+        ))));
         let app_data_2 = app_data.clone();
 
         let host = config.host.clone();
@@ -207,6 +220,7 @@ async fn post_rpc(
     let request = body.into_inner();
 
     let maybe_receiver = push_rpc_request(&mut data_guard, request);
+    let request_timeout = data_guard.timeout;
 
     drop(data_guard);
 
@@ -214,9 +228,9 @@ async fn post_rpc(
         return Ok(HttpResponse::Accepted().body("OK"));
     };
 
-    let result = timeout(TIMEOUT, receiver)
-        .await
-        .map_err(|_| ErrorInternalServerError(format!("Timed out max: {:?} seconds", TIMEOUT)))?;
+    let result = timeout(request_timeout, receiver).await.map_err(|_| {
+        ErrorInternalServerError(format!("Timed out max: {:?} seconds", request_timeout))
+    })?;
 
     let response = result.map_err(ErrorInternalServerError)?;
 
@@ -251,10 +265,11 @@ async fn get_ws(
                     };
 
                     let maybe_receiver = push_rpc_request(&mut data_guard, request);
+                    let request_timeout = data_guard.timeout;
                     drop(data_guard);
 
                     if let Some(receiver) = maybe_receiver {
-                        notify_session(session.clone(), receiver)
+                        notify_session(session.clone(), receiver, request_timeout)
                             .await
                             .unwrap_or_else(|e| error!("{}", e))
                     }
@@ -406,8 +421,9 @@ fn push_rpc_request(
 async fn notify_session(
     mut session: Session,
     receiver: Receiver<JsonRpcResponse>,
+    timeout_duration: Duration,
 ) -> Result<(), String> {
-    let response = timeout(TIMEOUT, receiver)
+    let response = timeout(timeout_duration, receiver)
         .await
         .map_err(|e| format!("ERR: TIMEOUT: {:?}", e))?
         .map_err(|e| format!("ERR: FAILED RES: {:?}", e))?;
@@ -421,4 +437,18 @@ async fn notify_session(
         .map_err(|e| format!("ERR: RESP SERDE FAILED: {:?}", e))?;
 
     Ok(())
+}
+
+fn get_timeout_duration_from_config(config: &ServerConfig) -> Duration {
+    match config.timeout {
+        Some(configured_timeout) => {
+            if configured_timeout == 0 {
+                warn!("Timeout is set to 0, using infinite timeout, this is NOT recommended.");
+                Duration::from_secs(u64::MAX)
+            } else {
+                Duration::from_secs(configured_timeout)
+            }
+        }
+        None => DEFAULT_TIMEOUT,
+    }
 }


### PR DESCRIPTION
This pull request introduces a configurable timeout mechanism for the JSON-RPC server, allowing the timeout duration to be set dynamically via the server configuration. It also includes minor updates to the package version in `Cargo.toml`. Below is a breakdown of the most important changes grouped by theme.

### Timeout Configuration Enhancements:

* **Added timeout field to `ServerConfig` and `AppData` structs**: The `ServerConfig` struct now includes an optional `timeout` field, and the `AppData` struct has a new `timeout` field to store the timeout duration. [[1]](diffhunk://#diff-6bc3d7d837db7edefec19a95b709a481191612f51e015235d353960832ee88b5R55) [[2]](diffhunk://#diff-6bc3d7d837db7edefec19a95b709a481191612f51e015235d353960832ee88b5R41)
* **Introduced `get_timeout_duration_from_config` function**: This function retrieves the timeout duration from the server configuration, defaulting to `DEFAULT_TIMEOUT` if no timeout is specified or using `u64::MAX` for infinite timeout when explicitly set to 0.
* **Updated `AppData::new` and `JsonRpcServer::new` to use dynamic timeout**: The `AppData::new` method now requires a timeout parameter, and the `JsonRpcServer::new` method initializes `AppData` with the timeout retrieved from the server configuration.
* **Replaced hardcoded timeout in async functions**: Timeout durations in `post_rpc`, `get_ws`, and `notify_session` functions are now dynamically retrieved from `AppData`, replacing the previous hardcoded `TIMEOUT` constant. [[1]](diffhunk://#diff-6bc3d7d837db7edefec19a95b709a481191612f51e015235d353960832ee88b5R223-R233) [[2]](diffhunk://#diff-6bc3d7d837db7edefec19a95b709a481191612f51e015235d353960832ee88b5R268-R272) [[3]](diffhunk://#diff-6bc3d7d837db7edefec19a95b709a481191612f51e015235d353960832ee88b5R424-R426)

### Miscellaneous Updates:

* **Renamed `TIMEOUT` to `DEFAULT_TIMEOUT`**: The constant defining the default timeout duration was renamed for clarity.
* **Updated package version in `Cargo.toml`**: Incremented the version from `0.0.6` to `0.0.7`.